### PR TITLE
add support for R950

### DIFF
--- a/smdk4412-common/proprietary/Android.mk
+++ b/smdk4412-common/proprietary/Android.mk
@@ -15,7 +15,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter i9300 n7100 n8000 n8013 t0lte i605 l900,$(TARGET_DEVICE)),)
+ifneq ($(filter i9300 n7100 n8000 n8013 t0lte i605 l900 r950,$(TARGET_DEVICE)),)
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := libTVOut


### PR DESCRIPTION
Allow the USC Note 2 to use smdk4412-common
