### PR TITLE
d2/jf: vendor-ize the camera blob

### DIFF
--- a/d2-common/d2-common-vendor-blobs.mk
+++ b/d2-common/d2-common-vendor-blobs.mk
@@ -83,7 +83,7 @@ PRODUCT_COPY_FILES += \
         vendor/samsung/d2-common/proprietary/lib/libyamaha.so:system/lib/libyamaha.so \
         vendor/samsung/d2-common/proprietary/lib/libmplmpu.so:system/lib/libmplmpu.so \
         vendor/samsung/d2-common/proprietary/bin/mm-qcamera-daemon:system/bin/mm-qcamera-daemon \
-        vendor/samsung/d2-common/proprietary/lib/hw/camera.msm8960.so:system/lib/hw/camera.msm8960.so \
+        vendor/samsung/d2-common/proprietary/lib/hw/camera.msm8960.so:system/lib/hw/vendor-camera.msm8960.so \
         vendor/samsung/d2-common/proprietary/lib/libmmjpeg.so:system/lib/libmmjpeg.so \
         vendor/samsung/d2-common/proprietary/lib/libmmstillomx.so:system/lib/libmmstillomx.so \
         vendor/samsung/d2-common/proprietary/lib/libimage-jpeg-enc-omx-comp.so:system/lib/libimage-jpeg-enc-omx-comp.so \

--- a/jf-common/jf-common-vendor-blobs.mk
+++ b/jf-common/jf-common-vendor-blobs.mk
@@ -104,7 +104,7 @@ PRODUCT_COPY_FILES += \
         vendor/samsung/jf-common/proprietary/cameradata/RS_M10MO_SS.bin:system/cameradata/RS_M10MO_SS.bin \
         vendor/samsung/jf-common/proprietary/cameradata/datapattern_420sp.yuv:system/cameradata/datapattern_420sp.yuv \
         vendor/samsung/jf-common/proprietary/cameradata/datapattern_front_420sp.yuv:system/cameradata/datapattern_front_420sp.yuv \
-        vendor/samsung/jf-common/proprietary/lib/hw/camera.msm8960.so:system/lib/hw/camera.msm8960.so \
+        vendor/samsung/jf-common/proprietary/lib/hw/camera.msm8960.so:system/lib/hw/vendor-camera.msm8960.so \
         vendor/samsung/jf-common/proprietary/lib/libchromatix_imx074_default_video.so:system/lib/libchromatix_imx074_default_video.so \
         vendor/samsung/jf-common/proprietary/lib/libchromatix_imx074_preview.so:system/lib/libchromatix_imx074_preview.so \
         vendor/samsung/jf-common/proprietary/lib/libchromatix_imx074_video_hd.so:system/lib/libchromatix_imx074_video_hd.so \


### PR DESCRIPTION
- We're using a wrapper now

Change-Id: Iaa06a5479e3cae765dbde4e6721d3ea14920096b
