### PR TITLE
jf: fix camera HAL filename

### DIFF
--- a/jf-common/jf-common-vendor-blobs.mk
+++ b/jf-common/jf-common-vendor-blobs.mk
@@ -105,7 +105,7 @@ PRODUCT_COPY_FILES += \
         vendor/samsung/jf-common/proprietary/cameradata/RS_M10MO_SS.bin:system/cameradata/RS_M10MO_SS.bin \
         vendor/samsung/jf-common/proprietary/cameradata/datapattern_420sp.yuv:system/cameradata/datapattern_420sp.yuv \
         vendor/samsung/jf-common/proprietary/cameradata/datapattern_front_420sp.yuv:system/cameradata/datapattern_front_420sp.yuv \
-        vendor/samsung/jf-common/proprietary/lib/hw/camera.msm8960.so:system/lib/hw/camera.msm8960.so \
+        vendor/samsung/jf-common/proprietary/lib/hw/camera.msm8960.so:system/lib/hw/vendor-camera.msm8960.so \
         vendor/samsung/jf-common/proprietary/lib/libadsprpc.so:system/lib/libadsprpc.so \
         vendor/samsung/jf-common/proprietary/lib/libchromatix_imx074_default_video.so:system/lib/libchromatix_imx074_default_video.so \
         vendor/samsung/jf-common/proprietary/lib/libchromatix_imx074_preview.so:system/lib/libchromatix_imx074_preview.so \


### PR DESCRIPTION
This needs to be named vendor-camera.msm8960.so for the wrapper

Change-Id: I592bf346f5faad5e78ddb93d7c5d38f74a9e81b7
