### PR TITLE
jf-common: Include jfltexx to build barrier

### DIFF
--- a/jf-common/Android.mk
+++ b/jf-common/Android.mk
@@ -16,7 +16,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter jactivelte jflte jflteatt jfltecan jfltecri jfltecsp jfltegsm jfltespr jfltetmo jflteusc jfltevzw,$(TARGET_DEVICE)),)
+ifneq ($(filter jactivelte jflte jfltexx jflteatt jfltecan jfltecri jfltecsp jfltegsm jfltespr jfltetmo jflteusc jfltevzw,$(TARGET_DEVICE)),)
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := libtime_genoff


### PR DESCRIPTION
Include jfltexx to build barrier for libtime_genoff.so.

Change-Id: I3c99d13b1e87986d3ef8e955e15c866da0d72b34
