### PR TITLE
Fix typo from order change

### DIFF
--- a/klte/klte-vendor-blobs.mk
+++ b/klte/klte-vendor-blobs.mk
@@ -31,7 +31,7 @@ PRODUCT_COPY_FILES += \
     vendor/samsung/klte/proprietary/vendor/lib/libizat_core.so:system/vendor/lib/libizat_core.so \
     vendor/samsung/klte/proprietary/vendor/lib/liblbs_core.so:system/vendor/lib/liblbs_core.so \
     vendor/samsung/klte/proprietary/vendor/firmware/libpn547_fw.so:system/vendor/firmware/libpn547_fw.so \
-    vendor/samsung/klte/proprietary/lib/libdsi_netctrl.so:system/lib/libdsi_netctrl.so \
+    vendor/samsung/klte/proprietary/vendor/lib/libdsi_netctrl.so:system/lib/libdsi_netctrl.so \
     vendor/samsung/klte/proprietary/lib/libmdmdetect.so:system/lib/libmdmdetect.so \
     vendor/samsung/klte/proprietary/lib/libperipheral_client.so:system/lib/libperipheral_client.so \
     vendor/samsung/klte/proprietary/vendor/lib/libconfigdb.so:system/vendor/lib/libconfigdb.so \


### PR DESCRIPTION
Order caused vendor to disappear from file which causes build error
