### PR TITLE
s3ve3gjv: regenerate makefiles

### DIFF
--- a/s3ve3gjv/s3ve3gjv-vendor.mk
+++ b/s3ve3gjv/s3ve3gjv-vendor.mk
@@ -44,4 +44,5 @@ PRODUCT_COPY_FILES += \
     vendor/samsung/s3ve3gjv/proprietary/vendor/lib/libmmcamera2_isp_modules.so:$(TARGET_COPY_OUT_VENDOR)/lib/libmmcamera2_isp_modules.so \
     vendor/samsung/s3ve3gjv/proprietary/vendor/lib/libmmcamera2_sensor_modules.so:$(TARGET_COPY_OUT_VENDOR)/lib/libmmcamera2_sensor_modules.so \
     vendor/samsung/s3ve3gjv/proprietary/vendor/lib/libmmcamera2_stats_modules.so:$(TARGET_COPY_OUT_VENDOR)/lib/libmmcamera2_stats_modules.so \
+    vendor/samsung/s3ve3gjv/proprietary/vendor/lib/libmmcamera_s5k4h5yb.so:$(TARGET_COPY_OUT_VENDOR)/lib/libmmcamera_s5k4h5yb.so \
     vendor/samsung/s3ve3gjv/proprietary/vendor/lib/liboemcamera.so:$(TARGET_COPY_OUT_VENDOR)/lib/liboemcamera.so


### PR DESCRIPTION
    * one of our camera libraries was left out from
      device-proprietary-files.txt, so regenerate makefiles after fixing
      device-proprietary-filex.txt in device tree